### PR TITLE
refactor: struttura BarNode (dominio prodotti_bar + compat) [SAFE]

### DIFF
--- a/.recovery/current-state.json
+++ b/.recovery/current-state.json
@@ -1,11 +1,9 @@
 {
-  "timestamp": "2025-10-05T20:55:12.253Z",
-  "snapshotId": "recovery-2025-10-05T20-55-12-250Z",
-  "branch": "main",
-  "lastCommit": "9653626327f76fbb08bf17cd9d14c92489e11b8d docs: final project analysis and documentation update",
-  "modifiedFiles": [
-    "\"DOCS/01-INFORMATIVI/06-REPORT_QUALITA\\314\\200.md\""
-  ],
+  "timestamp": "2025-10-05T21:54:34.144Z",
+  "snapshotId": "recovery-2025-10-05T21-54-34-140Z",
+  "branch": "prep/barnode-setup-clean",
+  "lastCommit": "f6f63e752356ccc6405a1e42ed66c606930c5a5a chore(setup): clean history snapshot for initial push [SAFE]",
+  "modifiedFiles": [],
   "activeTask": "Task generico",
   "reports": []
 }

--- a/DOCS/REPORT_SETUP_BARNODE_STEP1.md
+++ b/DOCS/REPORT_SETUP_BARNODE_STEP1.md
@@ -85,6 +85,29 @@
 - `package.json` - Nome progetto → "barnode"
 - `DOCS/00-INDICI/DOCS_INDEX.md` - Titolo aggiornato
 
+## 🏗️ STRUTTURA BARNODE (STEP 2)
+
+### Dominio ProdottiBar
+- **`src/domain/prodottiBar/types.ts`** - Tipo ProdottoBar con campo costo_prodotto
+- **`src/domain/prodottiBar/index.ts`** - Re-export del dominio
+- **`src/adapters/prodottiBarFromWines.ts`** - Adapter compatibilità WineType → ProdottoBar
+- **`src/hooks/useProdottiBar.ts`** - Hook wrapper che riusa useWines legacy
+
+### Compatibilità Layer
+- **Adapter**: Mapping WineType.name → ProdottoBar.nome, supplier → marca, etc.
+- **Hook**: useProdottiBar() riusa useWines() esistente + mapping
+- **Export**: Aggiunti re-export in src/contexts/index.ts
+
+### UI Updates
+- **Header**: Logo alt text "WINENODE" → "BARNODE"
+- **GestisciOrdiniPage**: Titolo "Gestisci Ordini" → "Gestisci Prodotti"
+- **CreaOrdinePage**: Pulsante "Gestisci Ordine" → "Gestisci Prodotti"
+
+### Note Tecniche
+- **`costo_prodotto`**: Campo previsto a codice, **NON** ancora persistito su DB
+- **Nessun DDL**: Continua ad usare tabelle "vini" esistenti
+- **Zero Breaking Changes**: useWines() e tutti i flussi esistenti invariati
+
 ---
 
 ## 🛡️ NOTE SICUREZZA

--- a/src/adapters/prodottiBarFromWines.ts
+++ b/src/adapters/prodottiBarFromWines.ts
@@ -1,0 +1,16 @@
+import type { ProdottoBar } from '@/domain/prodottiBar/types';
+import type { WineType } from '@/hooks/useWines';
+
+export function toProdottoBar(w: WineType): ProdottoBar {
+  return { 
+    id: w.id,
+    nome: w.name, // mapping name → nome
+    marca: w.supplier, // mapping supplier → marca
+    categoria: w.type, // mapping type → categoria
+    formato: w.vintage || undefined, // mapping vintage → formato
+    fornitore_id: null, // non presente in WineType legacy
+    costo_prodotto: w.cost || null, // mapping cost → costo_prodotto
+    created_at: undefined,
+    updated_at: undefined
+  }; 
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -2,3 +2,7 @@
 export { useOrdini, OrdiniProvider } from './OrdiniContext';
 export { OrdersProvider } from './OrdersProvider';
 export type { Ordine, OrdineDettaglio } from '../types/orders';
+
+// BarNode domain exports
+export { useProdottiBar } from '../hooks/useProdottiBar';
+export type { ProdottoBar } from '../domain/prodottiBar/types';

--- a/src/domain/prodottiBar/index.ts
+++ b/src/domain/prodottiBar/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/domain/prodottiBar/types.ts
+++ b/src/domain/prodottiBar/types.ts
@@ -1,0 +1,11 @@
+export type ProdottoBar = {
+  id: string;
+  nome: string;
+  marca?: string;
+  categoria?: string;
+  formato?: string;
+  fornitore_id?: string | null;
+  costo_prodotto?: number | null; // solo in memoria per ora
+  created_at?: string;
+  updated_at?: string;
+};

--- a/src/hooks/useProdottiBar.ts
+++ b/src/hooks/useProdottiBar.ts
@@ -1,0 +1,10 @@
+import { useWines } from './useWines'; // legacy
+import { toProdottoBar } from '@/adapters/prodottiBarFromWines';
+
+export function useProdottiBar() {
+  const wines = useWines(); // riusa logica esistente
+  return {
+    ...wines,
+    prodotti: wines.wines?.map(toProdottoBar) ?? [],
+  };
+}

--- a/src/pages/CreaOrdinePage.tsx
+++ b/src/pages/CreaOrdinePage.tsx
@@ -295,7 +295,7 @@ export default function CreaOrdinePage() {
             }}
             disabled={totalBottiglie === 0}
           >
-            Gestisci Ordine
+            Gestisci Prodotti
           </button>
         </div>
       </footer>

--- a/src/pages/GestisciOrdiniPage/index.tsx
+++ b/src/pages/GestisciOrdiniPage/index.tsx
@@ -80,7 +80,7 @@ export default function GestisciOrdiniPage() {
           }}>
             <div className="flex items-center justify-center">
               <h1 className="text-lg font-bold" style={{ color: '#541111' }}>
-                Gestisci Ordini
+                Gestisci Prodotti
               </h1>
             </div>
           </div>

--- a/src/pages/HomePage/components/Header.tsx
+++ b/src/pages/HomePage/components/Header.tsx
@@ -9,7 +9,7 @@ export function Header() {
             <source type="image/webp" srcSet="/logo1.webp" />
             <img 
               src="/logo1.png" 
-              alt="WINENODE"
+              alt="BARNODE"
               loading="eager"
               decoding="async"
             />


### PR DESCRIPTION
- Dominio prodotti_bar con tipo ProdottoBar + campo costo_prodotto (code-only)
- Adapter compatibilità WineType → ProdottoBar
- Hook useProdottiBar() wrapper su useWines() esistente
- UI copy: Gestisci Ordini → Gestisci Prodotti
- Zero DDL/DB changes, mantiene compatibilità totale
- Quality gates verdi: lint/typecheck/build/test